### PR TITLE
Fix "git clone" command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installation
 Run the following:
 
 ```bash
-git clone https://github.com/astranchet/pamplemousse.git .
+git clone https://github.com/astranchet/pamplemousse.git
 cd pamplemousse
 curl -s http://getcomposer.org/installer | php
 php composer.phar install


### PR DESCRIPTION
Using only "git clone" will create the "pamplemousse" directory used in the second command.
