### PR TITLE
Fix: do not crash when there is no photo

### DIFF
--- a/views/index.twig
+++ b/views/index.twig
@@ -27,7 +27,9 @@
         {% include 'partials/photoswipe.js.twig' %}
 
         {% set photo = photos|last %}
-        <button id="load" href="#" data-after="{{ photo.date_taken }}">Voir encore plus d'images !</button>
+        {% if photo %}
+            <button id="load" href="#" data-after="{{ photo.date_taken }}">Voir encore plus d'images !</button>
+        {% endif %}
     </section>
 {% endblock %}
 


### PR DESCRIPTION
An exception is thrown when there is no picture on the website. Not really a problem, but quite disturbing during setup.
