### PR TITLE
use preg_split instead of deprecated split

### DIFF
--- a/src/Pamplemousse/Photos/Router.php
+++ b/src/Pamplemousse/Photos/Router.php
@@ -25,7 +25,7 @@ class Router implements ControllerProviderInterface
 
         $checkThumbnailsSize = function (Request $request, Application $app) {
             foreach ($app['config']['thumbnails']['size'] as $size) {
-                list($width, $height) = split('x', $size);
+                list($width, $height) = preg_split('/x/', $size);
                 if ($width == $request->get('width') && $height == $request->get('height')) {
                     return null;
                 }

--- a/src/Pamplemousse/Photos/Service.php
+++ b/src/Pamplemousse/Photos/Service.php
@@ -316,7 +316,7 @@ class Service
     public function generateThumbnails($photo)
     {
         foreach ($this->app['config']['thumbnails']['size'] as $size) {
-            list($width, $height) = split('x', $size);
+            list($width, $height) = preg_split('/x/', $size);
             $this->generateThumbnail($photo, $width, $height);
         }
     }


### PR DESCRIPTION
http://php.net/manual/fr/function.split.php

> Avertissement This function was DEPRECATED in PHP 5.3.0, and REMOVED in PHP 7.0.0.
